### PR TITLE
allowing variadic arguments parsed equivalent to a slice

### DIFF
--- a/go-rpcgen.go
+++ b/go-rpcgen.go
@@ -336,6 +336,8 @@ func types(t ast.Expr) []string {
 		return types(n.Elt)
 	case *ast.Ident:
 		return []string{n.Name}
+	case *ast.Ellipsis:
+		return types(n.Elt)
 	default:
 		panic(fmt.Sprintf("unknown expression node %s %s\n", reflect.TypeOf(t), t))
 	}


### PR DESCRIPTION
Ran into an issue using this tool where it couldn't handle types with variadic arguments. This seems to work.